### PR TITLE
Adds parsing for highlighting lines in code blocks

### DIFF
--- a/lib/kramdown-parser-gfm-extractions.rb
+++ b/lib/kramdown-parser-gfm-extractions.rb
@@ -1,1 +1,4 @@
 require_relative "kramdown/parser/gfm_extractions"
+require_relative "rouge/formatters/html_line_highlighter_delegator"
+require "kramdown/converter/syntax_highlighter/rouge"
+require_relative "kramdown/converter/syntax_highlighter/rouge_patch"

--- a/lib/kramdown/converter/syntax_highlighter/rouge_patch.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge_patch.rb
@@ -1,0 +1,12 @@
+module Kramdown::Converter::SyntaxHighlighter
+  module Rouge
+    class << self
+      alias_method :old_options, :options
+
+      def options(converter, type)
+        opts = self.old_options(converter, type)
+        opts.merge(highlight_lines: converter.root.options[:line_numbers].shift)
+      end
+    end
+  end
+end

--- a/lib/kramdown/parser/gfm_extractions.rb
+++ b/lib/kramdown/parser/gfm_extractions.rb
@@ -5,42 +5,75 @@ module Kramdown
   module Parser
     class GFMExtractions < Kramdown::Parser::GFM
       FENCED_CODEBLOCK_MATCH = /^[ ]{0,3}(([~`]){3,})\s*?((.+?)(?:\?\S*)?)?\s*?\n(.*?)^[ ]{0,3}\1\2*\s*?\n/m.freeze
+      LINE_NUMBER_MATCH = /(?<lang>\w+){(?<line_numbers>[\d,-]+)}$/
 
       def parse_codeblock_fenced
-        if @src.check(FENCED_CODEBLOCK_MATCH) && @src[3].to_s.strip.include?(" ")
-          @src.pos += @src.matched_size
-          lang = @src[3].to_s.strip
-          lang = lang.split(" ")
+        @root.options[:line_numbers] ||= []
+        if @src.check(FENCED_CODEBLOCK_MATCH)
+          if match = @src[3].match(LINE_NUMBER_MATCH)
+            extract_line_numbers(match)
+          elsif @src[3].to_s.strip.include?(" ")
+            extract_mdjs
+          else
+            @root.options[:line_numbers] << []
+            super
+          end
+        end
+      end
 
-          sha = Digest::SHA2.hexdigest(@src[5])
-          @root.options[:extractions] ||= []
-          @root.options[:extractions] << {
-            sha: sha,
-            lang: lang[0],
-            meta: lang[1],
-            code: @src[5]
-          }
+      def extract_line_numbers(match)
+        line_number_groups = match[:line_numbers].split(",").map(&:strip)
+        line_numbers = line_number_groups.reduce([]) do |memo, line_number_group|
+          if range = line_number_group.match(/(\d+)-(\d+)/)
+            memo += (range[1].to_i..range[2].to_i).to_a
+          else
+            memo << line_number_group.to_i
+          end
+        end
+        start_line_number = @src.current_line_number
+        @src.pos += @src.matched_size
+        el = new_block_el(:codeblock, @src[5], nil, location: start_line_number, fenced: true)
+        lang = match[:lang]
+        unless lang.empty?
+          el.options[:lang] = lang
+          el.attr['class'] = "language-#{lang}"
+        end
+        @tree.children << el
+        @root.options[:line_numbers] << line_numbers
+        true
+      end
 
-          start_line_number = @src.current_line_number
+      def extract_mdjs
+        @src.pos += @src.matched_size
+        lang = @src[3].to_s.strip
+        lang = lang.split(" ")
 
-          unless options[:include_extraction_tags] == false
-            el = Element.new(:html_element, "kramdown-extraction", {id: "ex-#{sha}", lang: lang[0], meta: lang[1]}, category: :block, location: start_line_number, content_model: :raw)
+        sha = Digest::SHA2.hexdigest(@src[5])
+        @root.options[:extractions] ||= []
+        @root.options[:extractions] << {
+          sha: sha,
+          lang: lang[0],
+          meta: lang[1],
+          code: @src[5]
+        }
 
-            unless options[:include_code_in_extractions] == false
-              code_el = new_block_el(:codeblock, @src[5], nil, location: start_line_number, fenced: true)
-              code_el.options[:lang] = lang[0]
-              code_el.attr['class'] = "language-#{lang[0]}"
-              el.children << Element.new(:html_element, "template", nil, category: :block, location: start_line_number, content_model: :raw).tap do |tmpl|
-                tmpl.children << code_el
-              end
+        start_line_number = @src.current_line_number
+
+        unless options[:include_extraction_tags] == false
+          el = Element.new(:html_element, "kramdown-extraction", {id: "ex-#{sha}", lang: lang[0], meta: lang[1]}, category: :block, location: start_line_number, content_model: :raw)
+
+          unless options[:include_code_in_extractions] == false
+            code_el = new_block_el(:codeblock, @src[5], nil, location: start_line_number, fenced: true)
+            code_el.options[:lang] = lang[0]
+            code_el.attr['class'] = "language-#{lang[0]}"
+            el.children << Element.new(:html_element, "template", nil, category: :block, location: start_line_number, content_model: :raw).tap do |tmpl|
+              tmpl.children << code_el
             end
-
-            @tree.children << el
           end
 
+          @tree.children << el
+          @root.options[:line_numbers] << []
           true
-        else
-          super
         end
       end
     end

--- a/lib/rouge/formatters/html_line_highlighter_delegator.rb
+++ b/lib/rouge/formatters/html_line_highlighter_delegator.rb
@@ -1,0 +1,12 @@
+require "rouge"
+
+module Rouge
+  module Formatters
+    class HTMLLineHighligherDelegator < Rouge::Formatters::HTMLLineHighlighter
+      def initialize(opts)
+        delegate = Rouge::Formatters::HTML.new
+        super(delegate, opts)
+      end
+    end
+  end
+end

--- a/test/test_line_highlighting.rb
+++ b/test/test_line_highlighting.rb
@@ -1,0 +1,51 @@
+require "minitest/autorun"
+
+require "kramdown"
+require "kramdown-parser-gfm-extractions"
+
+class TestLineHighlighting < Minitest::Test
+  def setup
+    @text = <<~MD
+        # Regular Markdown Here
+
+        ```bash
+        ls unhighlighted_dir
+        ```
+
+        ```ruby{2-4,6,8}
+        class LineHighlighting
+          def highlighted_method
+            "this is all highlighted"
+          end
+
+          def partial_highlight
+            "this line is not highlighted"
+          end
+        end
+        ```
+
+        *More Markdown continues...*
+
+        ```javascript{1-3}
+        highlighted = function() {
+          "this can be highlighted as well";
+        }
+        ```
+    MD
+  end
+
+  def test_correct_output
+    doc = Kramdown::Document.new(
+      @text,
+      {
+        input: :GFMExtractions,
+        syntax_highlighter_opts:  {
+          block: { formatter: "HTMLLineHighligherDelegator" },
+        },
+      }
+    )
+    html = doc.to_html
+    assert html.scan("hll").size == 8
+  end
+end
+


### PR DESCRIPTION
- extracts line numbers from parentheses placed after language for
  fenced code blocks using regex matching
- passes line number for each code block to the HTML converter and
  syntax highter using  Kramdown root options :line_numbers array stack
- adds HTMLLineHighligherDelegator to setup the HTMLLineHighlighter
  initialization with the needed Rouge::Formatters::HTML first argument
- patches Kramdown::Converter::SyntaxHighlighter::Rouge by reopening the
  module and adding the highlight_lines option